### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server implementation that integrates the Tavily Search API, providing optimized search capabilities for LLMs.
 
+<a href="https://glama.ai/mcp/servers/0kmdibf9t1"><img width="380" height="200" src="https://glama.ai/mcp/servers/0kmdibf9t1/badge" alt="tavily-search-mcp-server MCP server" /></a>
+
 ## Features
 
 -   **Web Search:** Perform web searches optimized for LLMs, with control over search depth, topic, and time range.


### PR DESCRIPTION
This PR adds a badge for the [tavily-search-mcp-server](https://glama.ai/mcp/servers/0kmdibf9t1) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/0kmdibf9t1"><img width="380" height="200" src="https://glama.ai/mcp/servers/0kmdibf9t1/badge" alt="tavily-search-mcp-server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.