### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Tavily Search MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@apappascs/tavily-search-mcp-server)](https://smithery.ai/server/@apappascs/tavily-search-mcp-server)
 An MCP server implementation that integrates the Tavily Search API, providing optimized search capabilities for LLMs.
 
 <a href="https://glama.ai/mcp/servers/0kmdibf9t1"><img width="380" height="200" src="https://glama.ai/mcp/servers/0kmdibf9t1/badge" alt="tavily-search-mcp-server MCP server" /></a>
@@ -143,6 +144,14 @@ An MCP server implementation that integrates the Tavily Search API, providing op
     -   If you are using docker make sure you build the image first using `docker build -t tavily-search-mcp-server:latest .`
 
 4. Restart Claude Desktop for the changes to take effect.
+
+### Installing via Smithery
+
+To install Tavily Search for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@apappascs/tavily-search-mcp-server):
+
+```bash
+npx -y @smithery/cli install @apappascs/tavily-search-mcp-server --client claude
+```
 
 ## Environment Setup (for npm)
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - tavilyApiKey
+    properties:
+      tavilyApiKey:
+        type: string
+        description: API key for Tavily Search service.
+      transport:
+        type: string
+        default: stdio
+        description: Transport protocol to use (stdio or sse).
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: [`dist/${config.transport === 'sse' ? 'sse' : 'index'}.js`], env: { TAVILY_API_KEY: config.tavilyApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@apappascs/tavily-search-mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂